### PR TITLE
Add multi-CTN support and variation generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,5 @@ The app reads your OpenAI API key from the `OPENAI_API_KEY` environment variable
 
 After you upload an asset template you can generate marketing copy for the predefined AI fields. The character limits in the template are enforced and the generated text can be reviewed and edited before export.
 
+The interface allows entering multiple CTN numbers at once. For each CTN the app requests functional descriptions and then generates three variations of the marketing copy using OpenAI. The completed table can be downloaded as CSV or Excel for further editing.
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pandas
 openai
 PyPDF2
 python-dotenv
+openpyxl


### PR DESCRIPTION
## Summary
- support multiple CTNs with separate inputs
- generate three variations of copy per CTN using GPT
- include functional descriptions in the model prompt
- export as CSV or XLSX
- document new workflow

## Testing
- `python -m py_compile asset_app.py`
